### PR TITLE
correct letter case in file import path

### DIFF
--- a/client/src/components/Chat/Chat.jsx
+++ b/client/src/components/Chat/Chat.jsx
@@ -2,8 +2,8 @@ import React from 'react';
 import axios from 'axios';
 import { Button, Modal, ModalHeader, ModalBody, Input } from 'reactstrap';
 
-import Sub_previews from './sub_previews.jsx';
-import Sub_conversation from './sub_conversation.jsx';
+import Sub_previews from './Sub_previews.jsx';
+import Sub_conversation from './Sub_conversation.jsx';
 
 
 class Chat extends React.Component {


### PR DESCRIPTION
- file names are case sensitive in Linux, but not in (recent?) Mac OS
- corrected import statements in Chat.jsx to match case of file names