### PR TITLE
Distinguish in API Between Groups Owned and Groups Joined 

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ All API endpoints begin with /api.
   - [GET Data for Group by group_id](#info-for-specific-group)
   - [GET Search for Group by Name](#search-for-group-by-name)
   - [GET List Groups by Category](#list-groups-by-category)
-  - [GET List Groups for User](#list-groups-for-specific-user)
+  - [GET List Groups User is Member Of](#list-groups-user-is-member-of)
+  - [GET List Groups User is Owner Of](#list-groups-user-is-owner-of)
   - [GET List of Members of a Group](#members-in-specific-group)
   - [POST Create Group](#create-group)
 - [Events](#Events)
@@ -166,26 +167,50 @@ Same format as data at /api/groups
 
 
 
-### List Groups for specific user:
+### List Groups User is Member Of
 
-GET request to /api/users/:id/groups
+GET request to /api/users/:id/groups-member
 
 ```
 [
   {
     "group_id": 1,
-    "image_url": "assets/images/default-religious.jpg",
+    "image_url": "/assets/images/default-religious.jpg",
     "group_name": "JavaScript Meet Up",
-    "description": "We meet up and write code",
-    "category": "religious"
+    "description": "We like to code",
+    "category": "religious",
+    "owner": {
+      "user_id": 1,
+      "first_name": "Stephen",
+      "last_name": "Hyde",
+      "email": "stephen@friend.horse"
+    }
   },
+  ...
+]
+
+```
+
+### List Groups User is Owner Of
+
+GET request to /api/users/:id/groups-owned
+
+```
+[
   {
-    "group_id": 2,
-    "image_url": "assets/images/default-animals.jpg",
-    "group_name": "Cleveland Horse Enthusiasts",
-    "description": "We are enthusiastic about horses!",
-    "category": "animals"
-  }
+    "group_id": 1,
+    "image_url": "/assets/images/default-religious.jpg",
+    "group_name": "JavaScript Meet Up",
+    "description": "We like to code",
+    "category": "religious",
+    "owner": {
+      "user_id": 1,
+      "first_name": "Stephen",
+      "last_name": "Hyde",
+      "email": "stephen@friend.horse"
+    }
+  },
+  ...
 ]
 
 ```

--- a/server/routes/groups.js
+++ b/server/routes/groups.js
@@ -139,6 +139,70 @@ const getGroupById = (req, res) => {
   });
 };
 
+const getGroupsByOwnerId = (req, res) => {
+  const owner_id = req.params.user_id;
+  connection.query('SELECT g.group_id, g.image_url, g.group_name, g.description, g.category, g.owner_id, u.first_name, u.last_name, u.email FROM groups_table g LEFT JOIN users u ON g.owner_id = u.user_id WHERE g.owner_id = ?', [owner_id], (err, results) => {
+    if (err) {
+      return res.json({
+        error: err
+      });
+    }
+    const rows = results.map((row) => {
+      return {
+        group_id: row.group_id,
+        image_url: row.image_url,
+        group_name: row.group_name,
+        description: row.description,
+        category: row.category,
+        owner: {
+          user_id: row.owner_id,
+          first_name: row.first_name,
+          last_name: row.last_name,
+          email: row.email
+        }
+      }
+    });
+    return res.json(rows);
+  });
+}
+
+const getGroupsByMemberId = (req, res) => {
+  const member_id = req.params.user_id;
+  const sql = `
+    SELECT
+      g.group_id, g.image_url, g.group_name, g.description, g.category, g.owner_id,
+      u.first_name, u.last_name, u.email
+    FROM
+      groups_table g
+    LEFT JOIN users u ON g.owner_id = u.user_id
+    RIGHT JOIN members m ON g.group_id = m.group_id
+    WHERE m.user_id = ?
+  `;
+  connection.query(sql, [member_id], (err, results) => {
+    if (err) {
+      return res.json({
+        error: err
+      });
+    }
+    const rows = results.map((row) => {
+      return {
+        group_id: row.group_id,
+        image_url: row.image_url,
+        group_name: row.group_name,
+        description: row.description,
+        category: row.category,
+        owner: {
+          user_id: row.owner_id,
+          first_name: row.first_name,
+          last_name: row.last_name,
+          email: row.email
+        }
+      }
+    });
+    return res.json(rows);
+  });
+}
+
 const addGroup = (req, res) => {
   const errors = [];
   const validCategories = ['outdoors', 'music', 'cooking', 'animals', 'hobbies', 'religious'];
@@ -250,6 +314,8 @@ module.exports = {
   getAllGroups,
   findGroupByName,
   getGroupById,
+  getGroupsByOwnerId,
+  getGroupsByMemberId,
   getGroupsByCategory,
   addGroup
 };

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -17,6 +17,8 @@ router.get('/users/:user_id', users.getUserById);
 router.get('/users/:user_id/groups', members.getUserGroups);
 router.get('/users/:user_id/events', attendees.getUserEvents);
 router.get('/users/:user_id/dms', dms.getConversations);
+router.get('/users/:user_id/groups-owned', groups.getGroupsByOwnerId);
+router.get('/users/:user_id/groups-member', groups.getGroupsByMemberId);
 
 router.post('/users', users.addUser);
 router.post('/users/:user_id/groups/:group_id', members.addUserToGroup);


### PR DESCRIPTION
- created route for groups owned by a user (/api/users/:user_id/groups-owned)
- created route for groups joined by a user (/api/users/:user_id/groups-member)
- left old ambiguous route up to prevent breaking changes - will remove in future version

**Please Note: ** a user can be both a member of a group AND an owner. They can only RSVP to events if they are a member.